### PR TITLE
Fixed bind mount paths

### DIFF
--- a/templates/docker-compose.liquid
+++ b/templates/docker-compose.liquid
@@ -17,12 +17,12 @@ services:
       DATABASE_PASSWORD: ${DATABASE_PASSWORD}
       NODE_ENV: ${NODE_ENV}
     volumes:
-      - ./config:/opt/app/config
-      - ./src:/opt/app/src
-      - ./package.json:/opt/package.json
-      - ./yarn.lock:/opt/yarn.lock
-      - ./.env:/opt/app/.env
-      - ./public/uploads:/opt/app/public/uploads
+      - ./config:/app/config
+      - ./src:/app/src
+      - ./package.json:/app/package.json
+      - ./yarn.lock:/app/yarn.lock
+      - ./.env:/app/.env
+      - ./public/uploads:/app/public/uploads
     ports:
       - '1337:1337'
     networks:


### PR DESCRIPTION
I right now ran into this and didn't get why the container didn't write back the changes to the host files. 
Turns out the bind mount path were wrong and were pointing into `/opt/app` instead of `/app`. 