### PR TITLE
fix(quickstart.js): fixed an issue where we where not passing a name …

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ Please note the `new` keyword is required for this to take effect.
 
 ```markdown
 npx @strapi-community/dockerize new
+--projectname=<projectname>
 --dbtype=<dbclient>
 --dbhost=<dbhost>
 --dbport=<dbport>
@@ -70,6 +71,7 @@ npx @strapi-community/dockerize new
 ```markdown
 | 💻 Command     | 💬 Value                                | 🦄 Type | 🐲 Default    |
 | -------------- | --------------------------------------- | ------- | ------------- |
+| projectname    |                                         | String  | `mystrapi`    |
 | dbclient       | `postgres` \| `mysql` \| `mariadb`      | String  | `postgres`    |
 | dbhost         |                                         | String  | `localhost`   |
 | dbport         | `5432` \| `3306`                        | Number  | `5432`        |

--- a/cli/quickstart.js
+++ b/cli/quickstart.js
@@ -6,6 +6,7 @@ const { setConfig } = require(`../utils`);
  */
 const quickStart = async flags => {
 	const {
+		projectname,
 		projecttype,
 		packagemanager,
 		env,
@@ -19,6 +20,7 @@ const quickStart = async flags => {
 	} = flags;
 
 	setConfig({
+		projectName: projectname.toLowerCase() || `mystrapi`,
 		projectType: projecttype.toLowerCase(),
 		packageManager: packagemanager.toLowerCase(),
 		env: env.toLowerCase(),


### PR DESCRIPTION
…which is required

After previous changes we did not pass a projectname which is required, this was required to compose the files.

fix #38