### PR TITLE
fix yarn.lock folder bug

### DIFF
--- a/core/copyFiles.js
+++ b/core/copyFiles.js
@@ -59,7 +59,8 @@ const createDockerComposeFiles = async () => {
 		name: config.projectName,
 		env: config.env,
 		dbtype: config.dbtype,
-		dbport: config.dbport
+		dbport: config.dbport,
+		packageManager: config.packageManager
 	});
 	const filePath = path.join(config.outDir, `docker-compose.yml`);
 	await outputFile(filePath, template);

--- a/templates/docker-compose.liquid
+++ b/templates/docker-compose.liquid
@@ -20,7 +20,11 @@ services:
       - ./config:/opt/app/config
       - ./src:/opt/app/src
       - ./package.json:/opt/package.json
+{%- if packageManager == "npm" %}
+      - ./package-lock.json:/opt/package-lock.json
+{% else %}
       - ./yarn.lock:/opt/yarn.lock
+{% endif %}
       - ./.env:/opt/app/.env
       - ./public/uploads:/opt/app/public/uploads
     ports:


### PR DESCRIPTION
There is an error when you use npm as package manager. docker-compose mounts yarn.lock inside the docker image. If you're not using yarn, docker creates a `yarn.lock` folder and you will get an error if you want to install another package. This patch fixes this issue.