### PR TITLE
uses node:18-alpine in production image

### DIFF
--- a/templates/Dockerfile-prod.liquid
+++ b/templates/Dockerfile-prod.liquid
@@ -22,7 +22,7 @@ RUN npm run build
 {%- endif %}
 
 # Creating final production image
-FROM node:16-alpine
+FROM node:18-alpine
 RUN apk add --no-cache vips-dev
 ARG NODE_ENV=production
 ENV NODE_ENV=${NODE_ENV}


### PR DESCRIPTION
The final production image uses a different node version than the rest of the pipeline, this PR aligns the base image used for the final production image with the build one.