### PR TITLE
There is no default-authentication-plugin parameter in Mysql 8.4

### DIFF
--- a/templates/docker-compose.liquid
+++ b/templates/docker-compose.liquid
@@ -51,7 +51,7 @@ services:
 {% else %}
 {%- if dbtype == "mysql" %}
     image: mysql:latest
-    command: "--character-set-server=utf8mb4 --collation-server=utf8mb4_general_ci  --default-authentication-plugin=mysql_native_password"
+    command: "--character-set-server=utf8mb4 --collation-server=utf8mb4_general_ci  --mysql-native-password=ON"
     {%- else%}
     image: mariadb:latest
     {%- endif %}


### PR DESCRIPTION
I've faced an issue when using the strapi-tool-dockerize to create a docker image for my strapi / next.js app.

The docker-compose.yml includes a command for mysql which is no longer supported.
See https://stackoverflow.com/questions/78445419/unknown-variable-default-authentication-plugin-mysql-native-password
-> https://dev.mysql.com/doc/refman/8.4/en/native-pluggable-authentication.html

This PR will adopt the docker-compose.yml template to use the new command instead